### PR TITLE
feat: harden backup script and add pg_dump options + retention

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,20 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master
+        with:
+          scandir: "."
+          additional_files: "backup.sh"

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Environment Variable | Required | Default | Description
 `POSTGRES_DB` | No |  | The database to backup. By default, a backup of all the databases will be performed.
 `POSTGRES_USER` | No |  | The PostgreSQL user if any.
 `POSTGRES_PASSWORD` | No |  | The PostgreSQL password if any.
+`PGDUMP_EXTRA_OPTS` | No |  | Extra options passed verbatim to `pg_dump`, e.g. `--schema=public --no-owner`.
+`BACKUP_RETENTION_DAYS` | No |  | When set to a positive integer, backups for this `JOB_NAME` older than this many days are pruned from the bucket after a successful upload.
 `SLACK_AUTHOR_NAME` | No | `postgres-gcs-backup` | `true` slack author name.
 `SLACK_ALERTS` | No |  | `true` if you want to send Slack alerts in case of failure.
 `SLACK_WEBHOOK_URL` | No |  | The Incoming WebHook URL to use to send the alerts.
@@ -67,6 +69,13 @@ Please note that you can set any environment variable described in the previous 
     SLACK_CHANNEL=<slack_channel> \
     SLACK_USERNAME=<slack_username> \
     SLACK_ICON=<slack_icon> \
+    GCS_BUCKET=<gs://bucket_name> \
+    ./backup.sh
+
+To pass extra options to `pg_dump` and prune backups older than 7 days after a successful upload:
+
+    PGDUMP_EXTRA_OPTS="--schema=public --no-owner" \
+    BACKUP_RETENTION_DAYS=7 \
     GCS_BUCKET=<gs://bucket_name> \
     ./backup.sh
 

--- a/backup.sh
+++ b/backup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -o pipefail
 set -o errexit
 set -o errtrace
@@ -15,6 +15,11 @@ POSTGRES_PORT=${POSTGRES_PORT:-5432}
 POSTGRES_DB=${POSTGRES_DB:-}
 POSTGRES_USER=${POSTGRES_USER:-}
 POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-}
+# Extra options passed verbatim to pg_dump (word-split), e.g. "--schema=public --no-owner".
+PGDUMP_EXTRA_OPTS=${PGDUMP_EXTRA_OPTS:-}
+# When set to a positive integer, backups for this JOB_NAME older than this many
+# days are pruned from the bucket after a successful upload.
+BACKUP_RETENTION_DAYS=${BACKUP_RETENTION_DAYS:-}
 SLACK_ALERTS=${SLACK_ALERTS:-}
 SLACK_AUTHOR_NAME=${SLACK_AUTHOR_NAME:-postgres-gcs-backup}
 SLACK_WEBHOOK_URL=${SLACK_WEBHOOK_URL:-}
@@ -22,37 +27,48 @@ SLACK_CHANNEL=${SLACK_CHANNEL:-}
 SLACK_USERNAME=${SLACK_USERNAME:-}
 SLACK_ICON=${SLACK_ICON:-}
 
+# Populated by backup(); referenced by the EXIT trap so it must always be defined.
+archive_name=""
+
 backup() {
-  mkdir -p $BACKUP_DIR
+  mkdir -p "$BACKUP_DIR"
+  local date
   date=$(date "+%Y-%m-%dT%H:%M:%SZ")
   archive_name="$date-$JOB_NAME-backup.sql.gz"
-  cmd_auth_part=""
-  if [[ ! -z $POSTGRES_USER ]] && [[ ! -z $POSTGRES_PASSWORD ]]
-  then
-    cmd_auth_part="--username=\"$POSTGRES_USER\" "
-  fi
 
-  cmd_db_part=""
-  if [[ ! -z $POSTGRES_DB ]]
-  then
-    cmd_db_part="--db=\"$POSTGRES_DB\""
+  # Build the pg_dump arguments as an array so values with spaces are passed
+  # safely without eval.
+  local -a pg_dump_opts=(
+    "--host=$POSTGRES_HOST"
+    "--port=$POSTGRES_PORT"
+  )
+  if [[ -n $POSTGRES_USER ]]; then
+    pg_dump_opts+=("--username=$POSTGRES_USER")
+  fi
+  if [[ -n $POSTGRES_DB ]]; then
+    pg_dump_opts+=("--dbname=$POSTGRES_DB")
+  fi
+  if [[ -n $PGDUMP_EXTRA_OPTS ]]; then
+    # Intentional word splitting so callers can pass multiple options.
+    # shellcheck disable=SC2206
+    pg_dump_opts+=($PGDUMP_EXTRA_OPTS)
   fi
 
   export PGPASSWORD=$POSTGRES_PASSWORD
-  cmd="pg_dump --host=\"$POSTGRES_HOST\" --port=\"$POSTGRES_PORT\" $cmd_auth_part $cmd_db_part | gzip > $BACKUP_DIR/$archive_name"
-  echo "starting to backup PostGRES host=$POSTGRES_HOST port=$POSTGRES_PORT"
+  echo "starting to backup PostgreSQL host=$POSTGRES_HOST port=$POSTGRES_PORT db=${POSTGRES_DB:-<all>}"
 
-  eval "$cmd"
+  pg_dump "${pg_dump_opts[@]}" | gzip > "$BACKUP_DIR/$archive_name"
 }
 
-upload_to_gcs() {
-  if [[ ! "$GCS_BUCKET" =~ gs://* ]]; then
+normalize_bucket() {
+  if [[ ! "$GCS_BUCKET" =~ ^gs:// ]]; then
     GCS_BUCKET="gs://${GCS_BUCKET}"
   fi
+}
 
-  if [[ $GCS_KEY_FILE_PATH != "" ]]
-  then
-cat <<EOF > $BOTO_CONFIG_PATH
+write_boto_config() {
+  if [[ -n $GCS_KEY_FILE_PATH ]]; then
+    cat <<EOF > "$BOTO_CONFIG_PATH"
 [Credentials]
 gs_service_key_file = $GCS_KEY_FILE_PATH
 [Boto]
@@ -64,8 +80,53 @@ default_api_version = 2
 [OAuth2]
 EOF
   fi
+}
+
+upload_to_gcs() {
   echo "uploading backup archive to GCS bucket=$GCS_BUCKET"
-  gsutil cp $BACKUP_DIR/$archive_name $GCS_BUCKET
+  gsutil cp "$BACKUP_DIR/$archive_name" "$GCS_BUCKET"
+}
+
+# Prints an ISO 8601 UTC timestamp for "now minus $1 days".
+# Handles GNU coreutils, BSD (macOS) and busybox (alpine) date.
+iso_cutoff() {
+  local days=$1 now cutoff
+  now=$(date -u +%s)
+  cutoff=$(( now - days * 86400 ))
+  date -u -d "@$cutoff" "+%Y-%m-%dT%H:%M:%SZ" 2>/dev/null && return 0
+  date -u -r "$cutoff" "+%Y-%m-%dT%H:%M:%SZ" 2>/dev/null && return 0
+  return 1
+}
+
+# Removes backups for this JOB_NAME older than BACKUP_RETENTION_DAYS from the
+# bucket. Runs only after a successful upload and never fails the job: backups
+# are named "<ISO timestamp>-<JOB_NAME>-backup.sql.gz", so the timestamp prefix
+# can be compared lexicographically against the cutoff.
+prune_old_backups() {
+  [[ -z $BACKUP_RETENTION_DAYS ]] && return 0
+  if ! [[ $BACKUP_RETENTION_DAYS =~ ^[0-9]+$ ]]; then
+    echo "ignoring invalid BACKUP_RETENTION_DAYS='$BACKUP_RETENTION_DAYS' (expected a positive integer)" >&2
+    return 0
+  fi
+
+  local cutoff
+  if ! cutoff=$(iso_cutoff "$BACKUP_RETENTION_DAYS"); then
+    echo "could not compute retention cutoff; skipping prune" >&2
+    return 0
+  fi
+  echo "pruning backups for job=$JOB_NAME older than $cutoff ($BACKUP_RETENTION_DAYS days)"
+
+  local obj base ts
+  while read -r obj; do
+    [[ -z $obj ]] && continue
+    base=${obj##*/}
+    [[ $base == *-"$JOB_NAME"-backup.sql.gz ]] || continue
+    ts=${base%%-"$JOB_NAME"-backup.sql.gz}
+    if [[ $ts < $cutoff ]]; then
+      echo "deleting old backup $obj"
+      gsutil rm "$obj" || true
+    fi
+  done < <(gsutil ls "$GCS_BUCKET/" 2>/dev/null || true)
 }
 
 send_slack_message() {
@@ -73,7 +134,7 @@ send_slack_message() {
   local title=${2}
   local message=${3}
 
-  echo 'Sending to '${SLACK_CHANNEL}'...'
+  echo "Sending to ${SLACK_CHANNEL}..."
   curl --data-urlencode \
     "$(printf 'payload={"channel": "%s", "username": "%s", "link_names": "true", "icon_url": "%s", "attachments": [{"author_name": "%s", "title": "%s", "text": "%s", "color": "%s"}]}' \
         "${SLACK_CHANNEL}" \
@@ -84,25 +145,43 @@ send_slack_message() {
         "${message}" \
         "${color}" \
     )" \
-    ${SLACK_WEBHOOK_URL} || true
+    "${SLACK_WEBHOOK_URL}" || true
   echo
 }
 
 err() {
   err_msg="${JOB_NAME} Something went wrong on line $(caller)"
-  echo $err_msg >&2
-  if [[ $SLACK_ALERTS == "true" ]]
-  then
+  echo "$err_msg" >&2
+  if [[ $SLACK_ALERTS == "true" ]]; then
     send_slack_message "danger" "Error while performing postgres backup" "$err_msg"
   fi
 }
 
 cleanup() {
-  rm $BACKUP_DIR/$archive_name
+  if [[ -n $archive_name ]]; then
+    rm -f "$BACKUP_DIR/$archive_name"
+  fi
 }
 
-trap err ERR
-backup
-upload_to_gcs
-cleanup
-echo "backup done!"
+main() {
+  if [[ -z $GCS_BUCKET ]]; then
+    echo "GCS_BUCKET is required" >&2
+    exit 1
+  fi
+
+  trap err ERR
+  trap cleanup EXIT
+
+  normalize_bucket
+  write_boto_config
+  backup
+  upload_to_gcs
+  prune_old_backups
+  echo "backup done!"
+}
+
+# Only run the backup flow when executed directly; sourcing the script (e.g. in
+# tests) just loads the functions.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main
+fi


### PR DESCRIPTION
## Summary

Improves `backup.sh` across correctness, robustness, features, docs, and CI.

### Bug fixes
- **`--db` is not a valid `pg_dump` flag** — replaced with `--dbname`, so `POSTGRES_DB` actually works.
- `--username` is now passed whenever `POSTGRES_USER` is set, instead of only when a password is also provided.
- Replaced the fragile `eval`-based command construction with a quoted argument array (no more quoting/word-splitting surprises).
- The local dump is now removed on `EXIT` (via a trap), so a failed run no longer leaves a temp file behind. `rm -f` avoids erroring when there is nothing to remove.
- Fails early with a clear message when `GCS_BUCKET` is unset.

### Hardening
- All variable expansions quoted; the script passes **ShellCheck** cleanly (baseline had 7 SC2086 findings).
- The main flow is guarded behind a `BASH_SOURCE` check so the functions can be sourced and tested in isolation.

### New options
| Variable | Description |
|----------|-------------|
| `PGDUMP_EXTRA_OPTS` | Extra flags forwarded verbatim to `pg_dump`, e.g. `--schema=public --no-owner`. |
| `BACKUP_RETENTION_DAYS` | When set to a positive integer, prunes backups for this `JOB_NAME` older than N days from the bucket after a successful upload. |

Retention uses a portable `now - N days` cutoff (GNU/BSD/busybox `date`) and compares the ISO-8601 timestamp prefix in the object name lexicographically — only backups matching the current `JOB_NAME` are eligible, and pruning never fails the job.

### Docs & CI
- Documented the new options and added a usage example to the README.
- Added a ShellCheck GitHub Actions workflow (`.github/workflows/lint.yml`) on push/PR.

## Testing
- `shellcheck backup.sh` — clean.
- `bash -n` — syntax OK.
- End-to-end run with stubbed `pg_dump`/`gsutil`: bucket normalization, upload, retention prune (correctly keeps newer + other-job backups), and EXIT cleanup all verified.
- Error paths verified: missing `GCS_BUCKET` exits 1; a `pg_dump` failure fires the `err` trap and preserves the non-zero exit code.
- Retention filtering and the portable cutoff helper covered by a small source-and-stub test.